### PR TITLE
Break the tests for PredictMD into multiple stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,29 +49,35 @@ after_script:
 ############################################################################
 
 stages:
-    - "Stage 1 (latex-for-plotting build-and-test)"
-    - "Stage 2 (offlineregistry build-and-test)"
-    - "Stage 3 (predictmd build-and-test)"
+    - "Stage 1 (latex-for-plotting: build and test)"
+    - "Stage 2 (offlineregistry: build and test)"
+    - "Stage 3 (predictmd: build)"
+    - "Stage 4 (predictmd: test `all`)"
 
 ############################################################################
 
 jobs:
     include:
-        - stage: "Stage 1 (latex-for-plotting build-and-test)"
+        - stage: "Stage 1 (latex-for-plotting: build and test)"
           name: "dilumaluthge/latex-for-plotting"
           env:
               - IMAGE="latex-for-plotting"
           script: ./ci/travis/build-and-test.sh
-        - stage: "Stage 2 (offlineregistry build-and-test)"
+        - stage: "Stage 2 (offlineregistry: build and test)"
           name: "dilumaluthge/offlineregistry"
           env:
               - IMAGE="offlineregistry"
           script: ./ci/travis/build-and-test.sh
-        - stage: "Stage 3 (predictmd build-and-test)"
+        - stage: "Stage 3 (predictmd: build)"
+          name: "dilumaluthge/predictmd"
+          env:
+              - IMAGE="predictmd"
+          script: ./ci/travis/build.sh
+        - stage: "Stage 4 (predictmd: test `all`)"
           name: "dilumaluthge/predictmd"
           env:
               - IMAGE="predictmd"
               - PREDICTMD_TEST_GROUP="all"
-          script: ./ci/travis/build-and-test.sh
+          script: ./ci/travis/test.sh
 
 ############################################################################

--- a/ci/travis/build-and-test.sh
+++ b/ci/travis/build-and-test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-##### Beginning of file
-
 set -ev
 
 if [[ "$TRAVIS_BRANCH" == "master" ]]
@@ -66,5 +64,3 @@ fi
 pwd
 cd $TRAVIS_BUILD_DIR
 pwd
-
-##### End of file

--- a/ci/travis/build.sh
+++ b/ci/travis/build.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -ev
+
+if [[ "$TRAVIS_BRANCH" == "master" ]]
+then
+    export IMAGE_NAME_PREFIX=""
+else
+    if [[ "$TRAVIS_BRANCH" == "staging" ]]
+    then
+        export IMAGE_NAME_PREFIX="staging-"
+    else
+        if [[ "$TRAVIS_BRANCH" == "trying" ]]
+        then
+            export IMAGE_NAME_PREFIX="trying-"
+        else
+            export IMAGE_NAME_PREFIX="TRAVIS-DO-NOT-PUSH-"
+        fi
+    fi
+fi
+
+echo "IMAGE_NAME_PREFIX=$IMAGE_NAME_PREFIX"
+
+pwd
+cd $TRAVIS_BUILD_DIR
+pwd
+
+pwd
+cd docker
+pwd
+cd images
+pwd
+cd $IMAGE
+pwd
+
+make build
+make __travis-build-test-image__
+
+if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
+then
+    if [[ "$TRAVIS_BRANCH" == "master" ]]
+    then
+        echo "$DOCKER_BOT_PASSWORD" | docker login -u "$DOCKER_BOT_USERNAME" --password-stdin
+        make push
+    else
+        if [[ "$TRAVIS_BRANCH" == "staging" ]]
+        then
+            echo "$DOCKER_BOT_PASSWORD" | docker login -u "$DOCKER_BOT_USERNAME" --password-stdin
+            make push
+        else
+            if [[ "$TRAVIS_BRANCH" == "trying" ]]
+            then
+                echo "$DOCKER_BOT_PASSWORD" | docker login -u "$DOCKER_BOT_USERNAME" --password-stdin
+                make push
+            else
+                :
+            fi
+        fi
+    fi
+else
+    :
+fi
+
+pwd
+cd $TRAVIS_BUILD_DIR
+pwd

--- a/ci/travis/test.sh
+++ b/ci/travis/test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -ev
+
+if [[ "$TRAVIS_BRANCH" == "master" ]]
+then
+    export IMAGE_NAME_PREFIX=""
+else
+    if [[ "$TRAVIS_BRANCH" == "staging" ]]
+    then
+        export IMAGE_NAME_PREFIX="staging-"
+    else
+        if [[ "$TRAVIS_BRANCH" == "trying" ]]
+        then
+            export IMAGE_NAME_PREFIX="trying-"
+        else
+            export IMAGE_NAME_PREFIX="TRAVIS-DO-NOT-PUSH-"
+        fi
+    fi
+fi
+
+echo "IMAGE_NAME_PREFIX=$IMAGE_NAME_PREFIX"
+
+pwd
+cd $TRAVIS_BUILD_DIR
+pwd
+
+pwd
+cd docker
+pwd
+cd images
+pwd
+cd $IMAGE
+pwd
+
+make __travis-run-test-image__
+
+pwd
+cd $TRAVIS_BUILD_DIR
+pwd

--- a/docker/images/predictmd/Makefile
+++ b/docker/images/predictmd/Makefile
@@ -17,6 +17,7 @@ endif
 ##############################################################################
 
 .PHONY: default build push login test test-bash testbash
+.PHONY: __travis-build-test-image__ __travis-run-test-image__
 
 default: build
 
@@ -32,6 +33,12 @@ push: build
 
 test: build
 	cd testdir && $(DOCKERCMD) build -t $(DOCKER_IMAGE_OWNER)/$(IMAGE_NAME_PREFIX)test-$(DOCKER_IMAGE_NAME) .
+	$(DOCKERCMD) run --user predictmdtestuser --network none -it $(DOCKER_IMAGE_OWNER)/$(IMAGE_NAME_PREFIX)test-$(DOCKER_IMAGE_NAME) /bin/bash -c "/bin/runtests.sh $(PREDICTMD_TEST_GROUP) $(PREDICTMD_OPEN_PLOTS_DURING_TESTS)"
+
+__travis-build-test-image__: build
+	cd testdir && $(DOCKERCMD) build -t $(DOCKER_IMAGE_OWNER)/$(IMAGE_NAME_PREFIX)test-$(DOCKER_IMAGE_NAME) .
+
+__travis-run-test-image__:
 	$(DOCKERCMD) run --user predictmdtestuser --network none -it $(DOCKER_IMAGE_OWNER)/$(IMAGE_NAME_PREFIX)test-$(DOCKER_IMAGE_NAME) /bin/bash -c "/bin/runtests.sh $(PREDICTMD_TEST_GROUP) $(PREDICTMD_OPEN_PLOTS_DURING_TESTS)"
 
 test-bash: build


### PR DESCRIPTION
(based on the test groups `docker-1`, `docker-2`, etc.)

Fixes #68  
